### PR TITLE
Fix contents padding on main wrapper

### DIFF
--- a/src/styles/components/hamburger.module.scss
+++ b/src/styles/components/hamburger.module.scss
@@ -3,7 +3,7 @@
 .frame {
   display: flex;
   justify-content: right;
-  margin: 20px auto 0;
+  margin: 0 auto 10px;
   width: 100%;
 }
 

--- a/src/styles/globals.scss
+++ b/src/styles/globals.scss
@@ -15,7 +15,7 @@ body {
   font-size: 1.5rem;
 
   header {
-    margin: 0 0 30px;
+    margin: 0 0 15px;
     @include mq(tb) {
       display: flex;
       justify-content: space-between;
@@ -69,10 +69,12 @@ body {
 }
 
 body .contents {
-  margin: 0 auto;
+  margin: 0 16px;
   max-width: 1280px;
-  padding: 0 10%;
+  padding: 0 16px;
+  box-sizing: border-box;
   @include mq(tb) {
+    margin: 0 auto;
     padding: 0 40px;
   }
 }


### PR DESCRIPTION
## Summary
- add fixed horizontal padding and box-sizing to the shared contents wrapper so page sections no longer touch the viewport edge

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f704adc900832bb2b611ccdc013651